### PR TITLE
Add author filtering to `graph`

### DIFF
--- a/src/drivers/cli/driver.ts
+++ b/src/drivers/cli/driver.ts
@@ -27,25 +27,27 @@ For a list of subcommands, supply the "--help" argument.`);
     // Graph sub-command
     //
     .command("graph")
-    .description([
-      "Render a graph of pull requests for a repository.",
-      "",
-      "This graph shows pull request dependencies, and is most useful when",
-      "stacking pull requests. Dependencies are determined by base branch -",
-      "for example if PR #1 is on branch 'feature-1' and PR #2 has the base",
-      "branch of 'feature-1', #2 will render on top of #1 in the graph output.",
-      "",
-      "This command also looks for the first line in each PR description which",
-      "looks like this:",
-      "'* Diffbase: #123, #456'",
-      "The PRs referenced on this line are treated as dependencies of this PR,",
-      "similarly to the base-branch PRs above.",
-      "",
-      "If a PR has more than one base branch, it's a common pattern to upload",
-      "a 'merge-base' branch, which merges all diffbases of the PR. This",
-      "branch should match /merge[-_]base/, and this command will ignore such",
-      "branches.",
-    ].join("\n"))
+    .description(
+      [
+        "Render a graph of pull requests for a repository.",
+        "",
+        "This graph shows pull request dependencies, and is most useful when",
+        "stacking pull requests. Dependencies are determined by base branch -",
+        "for example if PR #1 is on branch 'feature-1' and PR #2 has the base",
+        "branch of 'feature-1', #2 will render on top of #1 in the graph output.",
+        "",
+        "This command also looks for the first line in each PR description which",
+        "looks like this:",
+        "'* Diffbase: #123, #456'",
+        "The PRs referenced on this line are treated as dependencies of this PR,",
+        "similarly to the base-branch PRs above.",
+        "",
+        "If a PR has more than one base branch, it's a common pattern to upload",
+        "a 'merge-base' branch, which merges all diffbases of the PR. This",
+        "branch should match /merge[-_]base/, and this command will ignore such",
+        "branches.",
+      ].join("\n")
+    )
     .option("--repo=[repo]", "The repository to render a graph for.", {
       required: true,
     })
@@ -57,18 +59,25 @@ For a list of subcommands, supply the "--help" argument.`);
     .option("--outputFormat=[outputFormat]", "The format of graph output.", {
       default: "mermaid",
     })
+    .option("--author=[author]", "Only fetch pull requests for this author.")
     .option("--authToken=[authToken]", "GitHub auth token credentials.")
     .action((options) => {
       z.object({
         repo: z.string(),
-        authToken: z.string().nullish().transform((x) => x ?? undefined),
         prState: z.enum(PULL_REQUEST_STATES),
         outputFormat: z.enum(OUTPUT_FORMATS),
-      }).safeParseAsync(options)
+        author: z.string().nullish().transform(x => x ?? undefined),
+        authToken: z
+          .string()
+          .nullish()
+          .transform((x) => x ?? undefined),
+      })
+        .safeParseAsync(options)
         .then((result) => {
           if (result.success) {
-            const { repo, authToken, prState, outputFormat } = result.data;
-            return graphCommand(repo, prState, outputFormat, authToken);
+            const { repo, authToken, prState, author, outputFormat } =
+              result.data;
+            return graphCommand(repo, prState, outputFormat, author, authToken);
           }
           console.error(result);
         });

--- a/src/graph/graph_command.ts
+++ b/src/graph/graph_command.ts
@@ -13,11 +13,13 @@ export const graphCommand = (
   repo: string,
   pullRequestState: PullRequestState,
   outputFormat: OutputFormat,
+  author?: string,
   authToken?: string,
 ): Promise<void> =>
   listPullRequests({
     repo,
     pullRequestState,
+    author,
     authToken,
   })
     .then((result) =>

--- a/src/pulls/list_pull_requests.ts
+++ b/src/pulls/list_pull_requests.ts
@@ -10,6 +10,7 @@ import { FutureResult } from "../util/future_result.ts";
 
 export interface listPullRequestsRequest {
   readonly repo: string;
+  readonly author?: string;
   readonly authToken?: string;
   readonly pullRequestState?: PullRequestState;
 }
@@ -18,47 +19,58 @@ export interface ListPullRequestsResponse {
   readonly pullRequests: readonly PullRequest[];
 }
 
-const RESPONSE_PARSER = z.array(
-  z.object({
-    url: z.string().url(),
-    html_url: z.string().url(),
-    state: z.enum(PULL_REQUEST_STATES),
-    number: z.number().positive(),
-    title: z.string(),
-    body: z.string().nullish().transform((x) => x ?? ""),
-    base: z.object({
-      label: z.string(),
+const RESPONSE_PARSER = z
+  .array(
+    z.object({
+      url: z.string().url(),
+      html_url: z.string().url(),
+      state: z.enum(PULL_REQUEST_STATES),
+      number: z.number().positive(),
+      title: z.string(),
+      body: z
+        .string()
+        .nullish()
+        .transform((x) => x ?? ""),
+      user: z.object({
+        login: z.string(),
+      }),
+      base: z.object({
+        label: z.string(),
+      }),
+      head: z.object({
+        label: z.string(),
+      }),
+    })
+  )
+  .transform((raws) => ({
+    pullRequests: raws.map<PullRequest>((raw) => {
+      const diffbase = (() => {
+        const diffbaseLine = raw.body
+          .split("\n")
+          .find((x) => x.toLowerCase().startsWith("* diffbase: "));
+
+        if (diffbaseLine === undefined) {
+          return [];
+        }
+
+        return diffbaseLine
+          .substring("* Diffbase: ".length)
+          .split(",")
+          .map((s) => parseInt(s.trim().replace("#", ""), 10));
+      })();
+
+      return {
+        ...raw,
+        kind: "PullRequest",
+        author: raw.user.login,
+        apiUrl: new URL(raw.url),
+        htmlUrl: new URL(raw.html_url),
+        branch: raw.head.label,
+        baseBranch: raw.base.label,
+        diffbase,
+      };
     }),
-    head: z.object({
-      label: z.string(),
-    }),
-  }),
-).transform((raws) => ({
-  pullRequests: raws.map<PullRequest>((raw) => {
-    const diffbase = (() => {
-      const diffbaseLine = raw.body.split("\n")
-        .find((x) => x.toLowerCase().startsWith("* diffbase: "));
-
-      if (diffbaseLine === undefined) {
-        return [];
-      }
-
-      return diffbaseLine.substring("* Diffbase: ".length)
-        .split(",")
-        .map((s) => parseInt(s.trim().replace("#", ""), 10));
-    })();
-
-    return {
-      ...raw,
-      kind: "PullRequest",
-      apiUrl: new URL(raw.url),
-      htmlUrl: new URL(raw.html_url),
-      branch: raw.head.label,
-      baseBranch: raw.base.label,
-      diffbase,
-    };
-  }),
-}));
+  }));
 
 /**
  * Returns a list of pull requests, using the given request.
@@ -66,12 +78,23 @@ const RESPONSE_PARSER = z.array(
  * Calls `https://api.github.com/repos/REPO/pulls, adapting the response.
  */
 export const listPullRequests = (
-  request: listPullRequestsRequest,
+  request: listPullRequestsRequest
 ): FutureResult<ListPullRequestsResponse> =>
   fetchGithub(
     `https://api.github.com/repos/${request.repo}/pulls?state=${
       request.pullRequestState ?? "open"
     }`,
     request.authToken,
-    RESPONSE_PARSER.safeParseAsync,
+    RESPONSE_PARSER.safeParseAsync
+  ).then((result) =>
+    result.map((response) => ({
+      ...response,
+      pullRequests: (() => {
+        if (request.author === undefined) {
+          return response.pullRequests;
+        }
+
+        return response.pullRequests.filter((x) => x.author === request.author);
+      })(),
+    }))
   );

--- a/src/pulls/pull_request.ts
+++ b/src/pulls/pull_request.ts
@@ -12,6 +12,7 @@ export interface PullRequest {
   readonly apiUrl: URL;
   readonly state: PullRequestState;
   readonly number: number;
+  readonly author: string;
   readonly title: string;
   readonly body: string;
   readonly branch: string;


### PR DESCRIPTION
This change allows an `author` field to be passed in via the command line, which when supplied will filter the author of fetched PRs.