### PR TITLE
Fix auth header

### DIFF
--- a/src/net/fetch_github.ts
+++ b/src/net/fetch_github.ts
@@ -11,7 +11,7 @@ export const fetchGithub = <T>(
     h.append("Accept", "application/vnd.github+json");
 
     if (authToken !== undefined) {
-      h.append("Authorization", authToken);
+      h.append("Authorization", `Bearer ${authToken}`);
     }
 
     return h;


### PR DESCRIPTION
This change fixes the auth header when sending requests to GitHub. Previously this header was not formatted properly.