### PR TITLE
Trent / Remove quotes from Mermaid output

### DIFF
--- a/src/graph/graph_command.ts
+++ b/src/graph/graph_command.ts
@@ -79,6 +79,8 @@ const renderMermaid = (prs: readonly PullRequest[]): string => {
       .replace(")", "")
       .replace("{", "")
       .replace("}", "")
+      .replace('"', "")
+      .replace("'", "")
       .replace("@", "");
 
   lines.push("graph TD");


### PR DESCRIPTION
__Trent / Remove quotes from Mermaid output__

Double quotes are illegal in mermaid node text, so this change removes them.

-----
* Closes #3 