### PR TITLE
Trent / Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @sixstring982 will be requested for review when someone
+# opens a pull request.
+*       @sixstring982


### PR DESCRIPTION
__Trent / Add CODEOWNERS file__

This change allows @Sixstring982 to be CODEOWNERS for this repo.
